### PR TITLE
cli-circle 3.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![cli-circle](http://i.imgur.com/MzPIRPD.png)](#)
 
-# cli-circle [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Travis](https://img.shields.io/travis/IonicaBizau/node-cli-circle.svg)](https://travis-ci.org/IonicaBizau/node-cli-circle/) [![Version](https://img.shields.io/npm/v/cli-circle.svg)](https://www.npmjs.com/package/cli-circle) [![Downloads](https://img.shields.io/npm/dt/cli-circle.svg)](https://www.npmjs.com/package/cli-circle) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# cli-circle
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Travis](https://img.shields.io/travis/IonicaBizau/node-cli-circle.svg)](https://travis-ci.org/IonicaBizau/node-cli-circle/) [![Version](https://img.shields.io/npm/v/cli-circle.svg)](https://www.npmjs.com/package/cli-circle) [![Downloads](https://img.shields.io/npm/dt/cli-circle.svg)](https://www.npmjs.com/package/cli-circle) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Generate ASCII circles with NodeJS.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-circle",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Generate ASCII circles with NodeJS.",
   "main": "lib/index.js",
   "directories": {
@@ -43,6 +43,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
