### PR TITLE
cli-circle 3.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ $ npm i --save cli-circle
 
 
 ```js
-// Dependencies
-var Circle = require("cli-circle");
+const circle = require("cli-circle");
 
 // Output the circle
-console.log(Circle(5).toString());
+console.log(circle(5).toString());
 // =>       • • • • •
 //        •           •
 //      •               •

--- a/example/index.js
+++ b/example/index.js
@@ -1,8 +1,9 @@
-// Dependencies
-var Circle = require("../lib");
+"use strict";
+
+const circle = require("../lib");
 
 // Output the circle
-console.log(Circle(5).toString());
+console.log(circle(5).toString());
 // =>       • • • • •
 //        •           •
 //      •               •

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
-// Dependencies
-var CliGraph = require("cli-graph")
-  , Ul = require("ul")
-  ;
+"use strict";
+
+const CliGraph = require("cli-graph")
+    , Ul = require("ul")
+    , typpy = require("typpy")
+    ;
 
 /**
  * CliCircle
@@ -21,7 +23,7 @@ var CliGraph = require("cli-graph")
  *
  */
 function CliCircle(radius, chr, opts) {
-    if (this.constructor !== CliCircle) {
+    if (!typpy(this, CliCircle)) {
         return new CliCircle(radius);
     }
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "cli-graph": "^3.0.0",
+    "typpy": "^2.3.3",
     "ul": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-circle",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Generate ASCII circles with NodeJS.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Fix a bug that appears in strict mode.

`this` is undefined when not calling the function using `new`, so use `typpy` to check if the context is a current instance, otherwise, create one. :boom:
